### PR TITLE
Center the map initially

### DIFF
--- a/gmap.html
+++ b/gmap.html
@@ -38,6 +38,7 @@
       src="https://maps.googleapis.com/maps/api/js?sensor=true">
     </script>
     <script type="text/javascript">
+    FirstPlane = true;
     Map=null;
     CenterLat=45.0;
     CenterLon=9.0;
@@ -121,8 +122,15 @@
                     if (myplane.hex == Selected)
                         refreshSelectedInfo();
                 } else {
+                    var latLong = new google.maps.LatLng(plane.lat, plane.lon);
+
+                    if (FirstPlane) {
+                        FirstPlane = false;
+                        Map.setCenter(latLong);
+                    }
+
                     marker = new google.maps.Marker({
-                        position: new google.maps.LatLng(plane.lat, plane.lon),
+                        position: latLong,
                         map: Map,
                         icon: getIconForPlane(plane)
                     });


### PR DESCRIPTION
This commit eliminates the need to move the map to your location every time you open the page by assuming the first plane that's picked up is in the same general area as all the others which will be picked up, which is a reasonable assumption for most use cases. This might be preferable to continually setting the center based on the plane data because this method doesn't remove any freedom from the user to pan around the map manually.
