### PR TITLE
Allow cross-site HTTP requests to data.json.

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -2260,6 +2260,7 @@ int handleHTTPRequest(struct client *c) {
         "Content-Type: %s\r\n"
         "Connection: %s\r\n"
         "Content-Length: %d\r\n"
+        "Access-Control-Allow-Origin: *\r\n"
         "\r\n",
         ctype,
         keepalive ? "keep-alive" : "close",


### PR DESCRIPTION
The `data.json` file is useful to access from other origin. This patch adds a `Access-Control-Allow-Origin: *` header to allow access from other HTTP servers.