### PR TITLE
Makefile updates for FreeBSD porting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-CFLAGS=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
-LIBS=`pkg-config --libs librtlsdr` -lpthread -lm
-CC=gcc
+CFLAGS?=-O2 -g -Wall -W `pkg-config --cflags librtlsdr`
+LDFLAGS?=`pkg-config --libs librtlsdr` -lpthread -lm
+CC?=gcc
 PROGNAME=dump1090
 
 all: dump1090
@@ -9,7 +9,7 @@ all: dump1090
 	$(CC) $(CFLAGS) -c $<
 
 dump1090: dump1090.o anet.o
-	$(CC) -g -o dump1090 dump1090.o anet.o $(LIBS)
+	$(CC) -g -o dump1090 dump1090.o anet.o $(LDFLAGS)
 
 clean:
 	rm -f *.o dump1090


### PR DESCRIPTION
I am in the process of creating a FreeBSD port of dump1090 and was hoping that these minor changes can be merged back which make it easier to build this software via the FreeBSD ports system.

The changes are renaming the LIBS variable to LDFLAGS and changing the assignment operator of CFLAGS and CC to be '?='