### PR TITLE
Fixes makefile on Debian based systems.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS?=-O2 -g -Wall -W $(shell pkg-config --cflags librtlsdr)
-LDLIBS+=$(shell pkg-config --libs librtlsdr) -lpthread -lm
+LDLIBS+=-lrtlsdr -L -lpthread -lm
 CC?=gcc
 PROGNAME=dump1090
 
@@ -9,7 +9,7 @@ all: dump1090
 	$(CC) $(CFLAGS) -c $<
 
 dump1090: dump1090.o anet.o
-	$(CC) -g -o dump1090 dump1090.o anet.o $(LDFLAGS) $(LDLIBS)
+	$(CC) -g -pthread -o dump1090 dump1090.o anet.o $(LDFLAGS) $(LDLIBS)
 
 clean:
 	rm -f *.o dump1090


### PR DESCRIPTION
Fixes #142 

This is the change that I made to fix the build process from producing the following errors on Raspberry Pi OS.

You might also need to run `sudo apt install rtl-sdr librtlsdr-dev` before this will build on a lite system.