### PR TITLE
function signature for sigWinchCallback to fix compile error

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -240,7 +240,7 @@ void useModesMessage(struct modesMessage *mm);
 int fixSingleBitErrors(unsigned char *msg, int bits);
 int fixTwoBitsErrors(unsigned char *msg, int bits);
 int modesMessageLenByType(int type);
-void sigWinchCallback();
+void sigWinchCallback(int);
 int getTermRows();
 
 /* ============================= Utility functions ========================== */
@@ -2426,7 +2426,7 @@ void modesWaitReadableClients(int timeout_ms) {
 /* ============================ Terminal handling  ========================== */
 
 /* Handle resizing terminal. */
-void sigWinchCallback() {
+void sigWinchCallback(int) {
     signal(SIGWINCH, SIG_IGN);
     Modes.interactive_rows = getTermRows();
     interactiveShowData();


### PR DESCRIPTION
C23 is more insistent that function pointers match the declared signature.  